### PR TITLE
Add support for aliased COUNT and CAST statements.

### DIFF
--- a/src/sqlingvo/compiler.clj
+++ b/src/sqlingvo/compiler.clj
@@ -158,14 +158,16 @@
                                [" END"]))
                 (compile-alias db (:as node)))))
 
-(defmethod compile-fn :cast [db {[expr type] :args}]
-  (concat-sql "CAST(" (compile-expr db expr) " AS " (name (:name type)) ")"))
+(defmethod compile-fn :cast [db {[expr type] :args as :as}]
+  (concat-sql "CAST(" (compile-expr db expr) " AS " (name (:name type)) ")"
+              (compile-alias db as)))
 
-(defmethod compile-fn :count [db {:keys [args]}]
+(defmethod compile-fn :count [db {:keys [args as]}]
   (concat-sql "count("
               (if (= 'distinct (:form (first args))) "DISTINCT ")
               (join-sql ", " (map #(compile-sql db %1)
-                                  (remove #(= 'distinct (:form %1)) args))) ")"))
+                                  (remove #(= 'distinct (:form %1)) args))) ")"
+              (compile-alias db as)))
 
 (defmethod compile-fn :in [db {[member expr] :args}]
   (concat-sql (compile-expr db member) " IN "

--- a/test/sqlingvo/core_test.clj
+++ b/test/sqlingvo/core_test.clj
@@ -63,6 +63,10 @@
   ["SELECT CAST(? AS int)" "1"]
   (select [`(cast "1" :int)]))
 
+(deftest-stmt test-cast-with-alias
+  ["SELECT CAST(? AS int) AS \"numeric_id\"" "1"]
+  (select [(as `(cast "1" :int) :numeric_id)]))
+
 ;; CREATE TABLE
 
 (deftest-stmt test-create-table-tmp-if-not-exists-inherits
@@ -418,6 +422,11 @@
   (is (= :select (:op stmt)))
   (is (= (map parse-expr [(as 1 :a) (as 2 :b) (as 3 :c)])
          (:exprs stmt))))
+
+(deftest-stmt test-select-count-as
+  ["SELECT count(*) AS \"count\" FROM \"tweets\""]
+  (select [(as '(count :*) :count)]
+    (from :tweets)))
 
 (deftest-stmt test-select-count-distinct
   ["SELECT count(DISTINCT \"user_id\") FROM \"tweets\""]


### PR DESCRIPTION
I noticed that if I attempt to alias a COUNT or a CAST statement, the alias doesn’t make it to the compiled SQL. Aliasing such columns simplifies results processing, i.e.

``` clojure
(apply jdbc/query
       db
       (sql (db-types/mysql)
            (select ['(count :*) '(count :deleted_at)]
                    (from :records))))
;;; bad
;;; ({:count(`deleted_at`) 270, :count(*) 1054})

(apply jdbc/query
       db
       (sql (db-types/mysql)
            (select [(as '(count :*) :total_count)
                     (as '(count :deleted_at) :deleted_count)]
                    (from :records))))
;;; good
;;; ({:deleted_count 270, :total_count 1054})
```

This is a very straightforward fix with some additional tests. Overall I feel like aliases compilation could be somehow decoupled from functions, but this would definitely require a significant amount of changes.
