### PR TITLE
Do not use LIMIT ALL

### DIFF
--- a/src/sqlingvo/compiler.clj
+++ b/src/sqlingvo/compiler.clj
@@ -408,7 +408,7 @@
   [(sql-quote db form)])
 
 (defmethod compile-sql :limit [db {:keys [count]}]
-  (concat-sql "LIMIT " (if (number? count) (str count) "ALL")))
+  (concat-sql (when (number? count) (str "LIMIT " count))))
 
 (defmethod compile-sql :like [db {:keys [excluding including table]}]
   (concat-sql
@@ -461,8 +461,8 @@
         (concat-sql " GROUP BY " (join-sql ", " (map #(compile-sql db %1) group-by))))
       (if-not (empty? order-by)
         (concat-sql " ORDER BY " (join-sql ", " (map #(compile-sql db %1) order-by))))
-      (if limit
-        (concat-sql " " (compile-sql db limit)))
+      (when-let [limit-sql (and limit (seq (compile-sql db limit)))]
+        (concat-sql " " limit-sql))
       (if offset
         (concat-sql " " (compile-sql db offset)))
       (if-not (empty? set)

--- a/test/sqlingvo/compiler_test.clj
+++ b/test/sqlingvo/compiler_test.clj
@@ -70,7 +70,7 @@
     {:op :limit :count 1}
     ["LIMIT 1"]
     {:op :limit :count nil}
-    ["LIMIT ALL"]))
+    []))
 
 (deftest test-compile-offset
   (are [ast expected]

--- a/test/sqlingvo/core_test.clj
+++ b/test/sqlingvo/core_test.clj
@@ -629,6 +629,12 @@
   (is (= [(parse-table :continents)] (:from stmt)))
   (is (= {:op :limit :count 10} (:limit stmt))))
 
+(deftest-stmt test-select-limit-nil
+  ["SELECT * FROM \"continents\""]
+  (select [*]
+    (from :continents)
+    (limit nil)))
+
 (deftest-stmt test-select-offset
   ["SELECT * FROM \"continents\" OFFSET 15"]
   (select [*]


### PR DESCRIPTION
LIMIT ALL is not supported by some major SQL databases, i.e. MySQL, SQLite. MS SQL Server and Oracle do not support the LIMIT statement completely. In any way, I believe the library should not automatically add any unexpected syntax.

It is useful to be able to remove existing LIMIT statements though. Especially when composing multiple queries, i.e.:

``` clojure
(sql (compose (select [:*] (from :users) (limit 10)) (limit nil)))
;;; ["SELECT * FROM \"users\""]
```

This change omits LIMIT section completely if a given value is not a number. I was also going to suggest a similar behavior for OFFSET, but it looks like OFFSET 0 (existing behavior) is widely supported and doesn’t cause any visible problems.
