### PR TITLE
Add support for MySQL’s LIMIT with optional offset argument.

### DIFF
--- a/src/sqlingvo/compiler.clj
+++ b/src/sqlingvo/compiler.clj
@@ -407,8 +407,10 @@
 (defmethod compile-sql :keyword [db {:keys [form]}]
   [(sql-quote db form)])
 
-(defmethod compile-sql :limit [db {:keys [count]}]
-  (concat-sql "LIMIT " (if (number? count) (str count) "ALL")))
+(defmethod compile-sql :limit [db {:keys [offset count]}]
+  (if-let [args (->> [offset count] (filter number?) (map str) seq)]
+    (concat-sql "LIMIT " (join-sql ", " args))
+    (concat-sql "LIMIT ALL")))
 
 (defmethod compile-sql :like [db {:keys [excluding including table]}]
   (concat-sql

--- a/src/sqlingvo/core.clj
+++ b/src/sqlingvo/core.clj
@@ -307,8 +307,10 @@ Examples:
 
 (defn limit
   "Returns a fn that adds a LIMIT clause to an SQL statement."
-  [count]
-  (assoc-op :limit :count count))
+  ([count]
+   (assoc-op :limit :count count))
+  ([offset count]
+   (assoc-op :limit :offset offset :count count)))
 
 (defn nulls
   "Parse `expr` and return an NULLS FIRST/LAST expr."

--- a/test/sqlingvo/core_test.clj
+++ b/test/sqlingvo/core_test.clj
@@ -629,6 +629,16 @@
   (is (= [(parse-table :continents)] (:from stmt)))
   (is (= {:op :limit :count 10} (:limit stmt))))
 
+(deftest-stmt test-select-limit-with-mysql-offset
+  ["SELECT * FROM \"continents\" LIMIT 20, 10"]
+  (select [*]
+    (from :continents)
+    (limit 20 10))
+  (is (= :select (:op stmt)))
+  (is (= [(parse-expr *)] (:exprs stmt)))
+  (is (= [(parse-table :continents)] (:from stmt)))
+  (is (= {:op :limit :count 10 :offset 20} (:limit stmt))))
+
 (deftest-stmt test-select-offset
   ["SELECT * FROM \"continents\" OFFSET 15"]
   (select [*]


### PR DESCRIPTION
MySQL supports a LIMIT statement with an optional offset argument, i.e. `LIMIT 10, 20` which stands for "fetch 20 records after skipping the first 10".

Noticed this while working on #18. I didn’t want to couple these changes, since I’m not sure if you’re interested in supporting such extensions of SQL standard. If you are, I can help with merging these.
