### PR TITLE
Added support for single sentence update counter upsert using "with"

### DIFF
--- a/test/sqlingvo/core_test.clj
+++ b/test/sqlingvo/core_test.clj
@@ -1439,6 +1439,21 @@
         (insert :product-logs []
           (select [:*] (from :moved-rows)))))
 
+(deftest-stmt test-with-counter-update
+  [(str "WITH upsert AS ("
+        "UPDATE \"counter_table\" SET counter = counter+1 "
+        "WHERE (\"id\" = ?) RETURNING *) "
+        "INSERT INTO \"counter_table\" (\"id\", \"counter\") "
+        "SELECT ?, 1 "
+        "WHERE (NOT EXISTS (SELECT * FROM \"upsert\"))")
+   "counter-name" "counter-name"]
+  (with [:upsert (update :counter_table '((= counter counter+1))
+                         (where '(= :id "counter-name"))
+                         (returning *))]
+        (insert :counter_table [:id :counter]
+                (select ["counter-name" 1])
+                (where `(not-exists ~(select [*] (from :upsert)))))))
+
 (deftest-stmt test-with-delete
   ["WITH t AS (DELETE FROM \"foo\") DELETE FROM \"bar\""]
   (with [:t (delete :foo)]


### PR DESCRIPTION
Generating the following recommended syntax for upserting a value in postgres 9.1+

```
WITH upsert AS ($upsert RETURNING *)
$insert WHERE NOT EXISTS (SELECT * FROM upsert);
```

Support for where clauses inside `insert` statements, and support for `exists` and `not-exists` functions was added.
