### PR TITLE
Add support for multiple expressions in partition by

### DIFF
--- a/src/sqlingvo/compiler.clj
+++ b/src/sqlingvo/compiler.clj
@@ -213,8 +213,13 @@
                 ")" (compile-alias db (:as node)))))
 
 (defmethod compile-fn :partition-by [db node]
-  (concat-sql "PARTITION BY "
-              (compile-sql-join db " " (:args node))))
+  (let [[expr & more-args] (:args node)]
+    (concat-sql "PARTITION BY "
+                (if (= :array (:op expr))
+                  (compile-sql-join db ", " (:children expr))
+                  (compile-expr db expr))
+                (when (seq more-args)
+                  (concat-sql " " (compile-sql-join db " " more-args))))))
 
 (defmethod compile-fn :order-by [db node]
   (concat-sql "ORDER BY " (compile-sql-join db ", " (:args node))))

--- a/test/sqlingvo/core_test.clj
+++ b/test/sqlingvo/core_test.clj
@@ -1600,10 +1600,20 @@
                 (from :empsalary)))
          ["SELECT \"depname\", \"empno\", \"salary\", \"avg\"(\"salary\") OVER (PARTITION BY \"depname\") FROM \"empsalary\""])))
 
+(deftest test-window-compare-salaries-by-year
+  (is (= (sql (select db [:year :depname :empno :salary '(over (avg :salary) (partition-by [:year :depname]))]
+                (from :empsalary)))
+         ["SELECT \"year\", \"depname\", \"empno\", \"salary\", \"avg\"(\"salary\") OVER (PARTITION BY \"year\", \"depname\") FROM \"empsalary\""])))
+
 (deftest test-window-rank-over-order-by
   (is (= (sql (select db [:depname :empno :salary '(over (rank) (partition-by :depname (order-by (desc :salary))))]
                 (from :empsalary)))
          ["SELECT \"depname\", \"empno\", \"salary\", \"rank\"() OVER (PARTITION BY \"depname\" ORDER BY \"salary\" DESC) FROM \"empsalary\""])))
+
+(deftest test-window-rank-over-multiple-cols-order-by
+  (is (= (sql (select db [:year :depname :empno :salary '(over (rank) (partition-by [:year :depname] (order-by (desc :salary))))]
+                (from :empsalary)))
+         ["SELECT \"year\", \"depname\", \"empno\", \"salary\", \"rank\"() OVER (PARTITION BY \"year\", \"depname\" ORDER BY \"salary\" DESC) FROM \"empsalary\""])))
 
 (deftest test-window-over-empty
   (is (= (sql (select db [:salary '(over (sum :salary))]


### PR DESCRIPTION
PARTITON BY supports multiple expressions in ANSI SQL2003. This is
implemented by PostgreSQL and other vendors. Allows passing a
single expression or a vector with multiple expressions to the
partition by fn as the first argument