### PR TITLE
Allow namespaced column keywords

### DIFF
--- a/src/sqlingvo/expr.cljc
+++ b/src/sqlingvo/expr.cljc
@@ -52,7 +52,7 @@
 
 (defn qualified-name
   "Returns the qualified name of `k`."
-  [k] (str/replace (str k) #"^:" ""))
+  [k] (if k (name k) ""))
 
 (defn unintern-name
   "Returns `x` without any namespace."

--- a/test/sqlingvo/expr_test.cljc
+++ b/test/sqlingvo/expr_test.cljc
@@ -278,7 +278,8 @@
     "" ""
     "continents" "continents"
     :continents "continents"
-    :public.continents "public.continents"))
+    :public.continents "public.continents"
+    :ns/continents "continents"))
 
 (deftest test-deref-statement
   (is (= @(select db [1])


### PR DESCRIPTION
It's possible I'm being naive about the intention of `qualified-name`, but currently it prevents the use of namespaced keywords as column names. I've changed the implementation to just use `name` instead of a regex, added one new test case and everything passes.